### PR TITLE
Add Meilisearch backend and indexing utilities

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3.7'
+services:
+  meilisearch:
+    image: getmeili/meilisearch:v1.7
+    environment:
+      - MEILI_NO_ANALYTICS=true
+      - MEILI_MASTER_KEY=${MEILI_MASTER_KEY:-masterKey}
+    ports:
+      - "7700:7700"
+    volumes:
+      - ./meili_data:/meili_data
+    command: meilisearch --db-path /meili_data --http-addr '0.0.0.0:7700'

--- a/backend/load_index.py
+++ b/backend/load_index.py
@@ -1,0 +1,56 @@
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, List
+
+from meilisearch import Client
+
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+DEFAULT_INDEX_FILE = BASE_DIR / "data/index.json"
+DEFAULT_INDEX_NAME = "documents"
+
+
+def load_index(index_file: Path = DEFAULT_INDEX_FILE, index_name: str = DEFAULT_INDEX_NAME) -> None:
+    """Load documents from a JSON file into a Meilisearch index.
+
+    Parameters
+    ----------
+    index_file:
+        Path to the JSON file containing the documents.
+    index_name:
+        Name of the Meilisearch index.
+    """
+    host = os.getenv("MEILISEARCH_HOST", "http://127.0.0.1:7700")
+    api_key = os.getenv("MEILISEARCH_API_KEY", "masterKey")
+
+    client = Client(host, api_key)
+
+    try:
+        index = client.get_index(index_name)
+    except Exception:
+        index = client.create_index(index_name, {"primaryKey": "id"})
+
+    with open(index_file, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    # The JSON may either be a list of documents or wrapped in a top-level key
+    documents: List[Dict[str, Any]]
+    if isinstance(data, dict) and "documents" in data:
+        documents = data["documents"]
+    else:
+        documents = data
+
+    index.update_filterable_attributes(["type", "source", "topics", "entities"])
+    index.add_documents(documents)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Load data/index.json into Meilisearch")
+    parser.add_argument("--index-file", type=Path, default=DEFAULT_INDEX_FILE)
+    parser.add_argument("--index-name", type=str, default=DEFAULT_INDEX_NAME)
+    args = parser.parse_args()
+
+    load_index(args.index_file, args.index_name)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,1 @@
+meilisearch>=0.31.1

--- a/backend/search.py
+++ b/backend/search.py
@@ -1,0 +1,79 @@
+import json
+import os
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+from meilisearch import Client
+
+
+DEFAULT_INDEX_NAME = "documents"
+
+
+def _build_filter(
+    types: Optional[Iterable[str]] = None,
+    sources: Optional[Iterable[str]] = None,
+    topics: Optional[Iterable[str]] = None,
+    entities: Optional[Iterable[str]] = None,
+) -> Optional[str]:
+    """Construct a Meilisearch filter string from provided filter values."""
+    filters: List[str] = []
+
+    def clause(field: str, values: Optional[Iterable[str]]) -> None:
+        if not values:
+            return
+        if isinstance(values, str):
+            values = [values]
+        parts = [f"{field} = '{v}'" for v in values]
+        filters.append("(" + " OR ".join(parts) + ")")
+
+    clause("type", types)
+    clause("source", sources)
+    clause("topics", topics)
+    clause("entities", entities)
+
+    return " AND ".join(filters) if filters else None
+
+
+def search(
+    query: str,
+    *,
+    types: Optional[Iterable[str]] = None,
+    sources: Optional[Iterable[str]] = None,
+    topics: Optional[Iterable[str]] = None,
+    entities: Optional[Iterable[str]] = None,
+    limit: int = 20,
+    index_name: str = DEFAULT_INDEX_NAME,
+) -> dict:
+    """Search the index with optional filters."""
+    host = os.getenv("MEILISEARCH_HOST", "http://127.0.0.1:7700")
+    api_key = os.getenv("MEILISEARCH_API_KEY", "masterKey")
+    client = Client(host, api_key)
+    index = client.index(index_name)
+
+    filter_str = _build_filter(types, sources, topics, entities)
+    return index.search(query, {"filter": filter_str, "limit": limit})
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Query the Meilisearch index")
+    parser.add_argument("query")
+    parser.add_argument("--type", dest="types", action="append")
+    parser.add_argument("--source", dest="sources", action="append")
+    parser.add_argument("--topic", dest="topics", action="append")
+    parser.add_argument("--entity", dest="entities", action="append")
+    parser.add_argument("--limit", type=int, default=20)
+    parser.add_argument("--index-name", default=DEFAULT_INDEX_NAME)
+    args = parser.parse_args()
+
+    result = search(
+        args.query,
+        types=args.types,
+        sources=args.sources,
+        topics=args.topics,
+        entities=args.entities,
+        limit=args.limit,
+        index_name=args.index_name,
+    )
+    print(json.dumps(result, indent=2))


### PR DESCRIPTION
## Summary
- add docker compose configuration for Meilisearch
- create loader script to import `data/index.json` into the index with filterable attributes
- provide search utility supporting filters for type, source, topics, and entities

## Testing
- `python -m py_compile backend/load_index.py backend/search.py`


------
https://chatgpt.com/codex/tasks/task_e_68b846fe5d948330bf3e7f0cc2fdc189