### PR TITLE
feat: add global search component

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import './App.css';
 import DocumentBrowser from './components/DocumentBrowser';
+import GlobalSearch from './components/GlobalSearch';
 
 function App() {
   return (
     <div className="App">
       <h1>Document Browser</h1>
+      <GlobalSearch />
       <DocumentBrowser />
     </div>
   );

--- a/frontend/src/components/GlobalSearch.jsx
+++ b/frontend/src/components/GlobalSearch.jsx
@@ -1,0 +1,76 @@
+import React, { useEffect, useState } from 'react';
+
+function GlobalSearch() {
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState([]);
+
+  useEffect(() => {
+    if (!query) {
+      setResults([]);
+      return;
+    }
+
+    const controller = new AbortController();
+
+    const timeout = setTimeout(async () => {
+      try {
+        const res = await fetch(`/search?q=${encodeURIComponent(query)}`, {
+          signal: controller.signal
+        });
+        if (!res.ok) return;
+        const data = await res.json();
+        setResults(data.hits || []);
+      } catch (err) {
+        if (err.name !== 'AbortError') console.error(err);
+      }
+    }, 300);
+
+    return () => {
+      clearTimeout(timeout);
+      controller.abort();
+    };
+  }, [query]);
+
+  return (
+    <div>
+      <input
+        type="text"
+        value={query}
+        placeholder="Search..."
+        onChange={(e) => setQuery(e.target.value)}
+        autoComplete="off"
+      />
+      {results.length > 0 && (
+        <ul>
+          {results.map((hit) => {
+            const snippet =
+              (hit._formatted &&
+                (hit._formatted.content || hit._formatted.text || '')) ||
+              '';
+            return (
+              <li key={hit.id} style={{ marginBottom: '1rem' }}>
+                <strong>{hit.title || hit.id}</strong>
+                {snippet && (
+                  <div
+                    style={{ fontSize: '0.9rem' }}
+                    dangerouslySetInnerHTML={{ __html: snippet }}
+                  />
+                )}
+                {hit.source && <div>Source: {hit.source}</div>}
+                {hit.topics && hit.topics.length > 0 && (
+                  <div>Topics: {hit.topics.join(', ')}</div>
+                )}
+                {hit.entities && hit.entities.length > 0 && (
+                  <div>Entities: {hit.entities.join(', ')}</div>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+export default GlobalSearch;
+


### PR DESCRIPTION
## Summary
- add GlobalSearch component for querying `/search`
- render snippets along with source, topic, and entity facets
- integrate GlobalSearch into main app

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b84d1bf334833089614197e2ecf1c6