### PR TITLE
Add Cytoscape-based connections map component

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "cytoscape": "^3.33.1",
         "react": "^19.1.1",
         "react-dom": "^19.1.1"
       },
@@ -1638,6 +1639,15 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cytoscape": {
+      "version": "3.33.1",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
+      "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "cytoscape": "^3.33.1",
     "react": "^19.1.1",
     "react-dom": "^19.1.1"
   },

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import './App.css';
 import DocumentBrowser from './components/DocumentBrowser';
 import GlobalSearch from './components/GlobalSearch';
+import ConnectionsMap from './components/ConnectionsMap';
 
 function App() {
   return (
@@ -9,6 +10,7 @@ function App() {
       <h1>Document Browser</h1>
       <GlobalSearch />
       <DocumentBrowser />
+      <ConnectionsMap />
     </div>
   );
 }

--- a/frontend/src/components/ConnectionsMap.jsx
+++ b/frontend/src/components/ConnectionsMap.jsx
@@ -1,0 +1,160 @@
+import React, { useEffect, useRef, useState } from 'react';
+import cytoscape from 'cytoscape';
+
+function ConnectionsMap() {
+  const containerRef = useRef(null);
+  const [selected, setSelected] = useState(null);
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+
+    const cy = cytoscape({
+      container: containerRef.current,
+      elements: [
+        // Nodes
+        {
+          data: {
+            id: 'person1',
+            label: 'Alice',
+            type: 'person',
+            metadata: { role: 'Researcher' }
+          }
+        },
+        {
+          data: {
+            id: 'org1',
+            label: 'Acme Corp',
+            type: 'organization',
+            metadata: { location: 'NYC' }
+          }
+        },
+        {
+          data: {
+            id: 'doc1',
+            label: 'Doc A',
+            type: 'document',
+            metadata: {
+              url: 'https://example.com/doc-a',
+              title: 'Doc A'
+            }
+          }
+        },
+        {
+          data: {
+            id: 'doc2',
+            label: 'Doc B',
+            type: 'document',
+            metadata: {
+              url: 'https://example.com/doc-b',
+              title: 'Doc B'
+            }
+          }
+        },
+        // Edges
+        {
+          data: {
+            id: 'p1d1',
+            source: 'person1',
+            target: 'doc1',
+            label: 'erwähnt in'
+          }
+        },
+        {
+          data: {
+            id: 'o1d1',
+            source: 'org1',
+            target: 'doc1',
+            label: 'erwähnt in'
+          }
+        },
+        {
+          data: {
+            id: 'd1d2',
+            source: 'doc1',
+            target: 'doc2',
+            label: 'verlinkt mit',
+            type: 'link'
+          }
+        }
+      ],
+      style: [
+        {
+          selector: 'node',
+          style: {
+            label: 'data(label)',
+            'text-valign': 'center',
+            'text-halign': 'center',
+            color: '#fff'
+          }
+        },
+        {
+          selector: 'node[type="person"]',
+          style: { 'background-color': '#3498db' }
+        },
+        {
+          selector: 'node[type="organization"]',
+          style: { 'background-color': '#2ecc71' }
+        },
+        {
+          selector: 'node[type="document"]',
+          style: { 'background-color': '#e67e22' }
+        },
+        {
+          selector: 'edge',
+          style: {
+            label: 'data(label)',
+            'curve-style': 'bezier',
+            'target-arrow-shape': 'triangle',
+            'line-color': '#ccc',
+            'target-arrow-color': '#ccc',
+            'font-size': 10
+          }
+        },
+        {
+          selector: 'edge[type="link"]',
+          style: { 'line-style': 'dashed' }
+        }
+      ],
+      layout: { name: 'grid' }
+    });
+
+    cy.on('tap', 'node', (evt) => {
+      const data = evt.target.data();
+      setSelected(data);
+    });
+
+    return () => cy.destroy();
+  }, []);
+
+  return (
+    <div>
+      <div
+        ref={containerRef}
+        style={{ width: '600px', height: '400px', border: '1px solid #ccc' }}
+      />
+      {selected && (
+        <div style={{ marginTop: '1rem' }}>
+          <h3>{selected.label}</h3>
+          {selected.metadata && (
+            <div>
+              {Object.entries(selected.metadata).map(([key, value]) => (
+                <div key={key}>
+                  <strong>{key}:</strong>{' '}
+                  {key === 'url' ? (
+                    <a href={value} target="_blank" rel="noreferrer">
+                      {value}
+                    </a>
+                  ) : (
+                    value
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default ConnectionsMap;


### PR DESCRIPTION
## Summary
- add ConnectionsMap React component using Cytoscape.js to visualize people, organizations, and documents with relation edges
- integrate ConnectionsMap into the main app and color-code nodes by type
- include cytoscape dependency

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b84e7bf5c083309e186542c83e0426