### PR TITLE
feat: add GeoMap component with geocoding and heatmap

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,8 +9,11 @@
       "version": "0.0.0",
       "dependencies": {
         "cytoscape": "^3.33.1",
+        "leaflet": "^1.9.4",
+        "leaflet.heat": "^0.2.0",
         "react": "^19.1.1",
-        "react-dom": "^19.1.1"
+        "react-dom": "^19.1.1",
+        "react-leaflet": "^5.0.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.33.0",
@@ -1019,6 +1022,17 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@react-leaflet/core": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-3.0.0.tgz",
+      "integrity": "sha512-3EWmekh4Nz+pGcr+xjf0KNyYfC3U2JjnkWsh0zcqaexYqmmB5ZhH37kz41JXGmKzpaMZCnPofBBm64i+YrEvGQ==",
+      "license": "Hippocratic-2.1",
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -2219,6 +2233,17 @@
         "json-buffer": "3.0.1"
       }
     },
+    "node_modules/leaflet": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/leaflet.heat": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/leaflet.heat/-/leaflet.heat-0.2.0.tgz",
+      "integrity": "sha512-Cd5PbAA/rX3X3XKxfDoUGi9qp78FyhWYurFg3nsfhntcM/MCNK08pRkf4iEenO1KNqwVPKCmkyktjW3UD+h9bQ=="
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -2490,6 +2515,20 @@
       },
       "peerDependencies": {
         "react": "^19.1.1"
+      }
+    },
+    "node_modules/react-leaflet": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-5.0.0.tgz",
+      "integrity": "sha512-CWbTpr5vcHw5bt9i4zSlPEVQdTVcML390TjeDG0cK59z1ylexpqC6M1PJFjV8jD7CF+ACBFsLIDs6DRMoLEofw==",
+      "license": "Hippocratic-2.1",
+      "dependencies": {
+        "@react-leaflet/core": "^3.0.0"
+      },
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
       }
     },
     "node_modules/react-refresh": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,8 +11,11 @@
   },
   "dependencies": {
     "cytoscape": "^3.33.1",
+    "leaflet": "^1.9.4",
+    "leaflet.heat": "^0.2.0",
     "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react-dom": "^19.1.1",
+    "react-leaflet": "^5.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,6 +3,7 @@ import './App.css';
 import DocumentBrowser from './components/DocumentBrowser';
 import GlobalSearch from './components/GlobalSearch';
 import ConnectionsMap from './components/ConnectionsMap';
+import GeoMap from './components/GeoMap';
 
 function App() {
   return (
@@ -11,6 +12,25 @@ function App() {
       <GlobalSearch />
       <DocumentBrowser />
       <ConnectionsMap />
+      <GeoMap
+        locations={[
+          {
+            name: 'Berlin',
+            documents: [
+              { id: 1, title: 'Berlin Report' },
+              { id: 2, title: 'City History' },
+            ],
+          },
+          {
+            name: 'Paris',
+            documents: [{ id: 3, title: 'Paris Overview' }],
+          },
+          {
+            name: 'New York',
+            documents: [{ id: 4, title: 'NYC Document' }],
+          },
+        ]}
+      />
     </div>
   );
 }

--- a/frontend/src/components/GeoMap.jsx
+++ b/frontend/src/components/GeoMap.jsx
@@ -1,0 +1,102 @@
+import React, { useEffect, useState } from 'react';
+import { MapContainer, TileLayer, Marker, Popup, useMap } from 'react-leaflet';
+import 'leaflet/dist/leaflet.css';
+import L from 'leaflet';
+import 'leaflet.heat';
+
+// Fix default icon paths for Leaflet when used with bundlers
+import markerIcon from 'leaflet/dist/images/marker-icon.png';
+import markerShadow from 'leaflet/dist/images/marker-shadow.png';
+
+L.Icon.Default.mergeOptions({
+  iconUrl: markerIcon,
+  shadowUrl: markerShadow,
+});
+
+function HeatLayer({ points }) {
+  const map = useMap();
+  useEffect(() => {
+    if (!points || !points.length) return;
+    const layer = L.heatLayer(points, { radius: 25 });
+    layer.addTo(map);
+    return () => {
+      layer.remove();
+    };
+  }, [map, points]);
+  return null;
+}
+
+/**
+ * GeoMap component
+ * @param {{locations: Array<{ name: string, documents: Array<{id:string|number,title:string}> }>}} props
+ */
+function GeoMap({ locations }) {
+  const [places, setPlaces] = useState([]); // [{name, documents, lat, lon}]
+  const [heatMode, setHeatMode] = useState(false);
+
+  useEffect(() => {
+    async function geocode() {
+      const results = await Promise.all(
+        locations.map(async (loc) => {
+          const url = `https://nominatim.openstreetmap.org/search?format=json&q=${encodeURIComponent(
+            loc.name,
+          )}`;
+          try {
+            const res = await fetch(url);
+            const data = await res.json();
+            if (data && data.length) {
+              return {
+                ...loc,
+                lat: parseFloat(data[0].lat),
+                lon: parseFloat(data[0].lon),
+              };
+            }
+          } catch (err) {
+            console.error('Geocoding error', err);
+          }
+          return null;
+        }),
+      );
+      setPlaces(results.filter(Boolean));
+    }
+
+    geocode();
+  }, [locations]);
+
+  const center = places.length
+    ? [places[0].lat, places[0].lon]
+    : [51.1657, 10.4515]; // Default: Germany
+
+  const heatPoints = places.map((p) => [p.lat, p.lon, p.documents.length]);
+
+  return (
+    <div>
+      <button type="button" onClick={() => setHeatMode((m) => !m)}>
+        {heatMode ? 'Show Markers' : 'Show Heatmap'}
+      </button>
+      <MapContainer center={center} zoom={4} style={{ height: '400px', width: '100%' }}>
+        <TileLayer
+          url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+          attribution="&copy; OpenStreetMap contributors"
+        />
+        {heatMode && <HeatLayer points={heatPoints} />}
+        {!heatMode &&
+          places.map((p) => (
+            <Marker key={p.name} position={[p.lat, p.lon]}>
+              <Popup>
+                <strong>{p.name}</strong>
+                <ul>
+                  {p.documents.map((d) => (
+                    <li key={d.id}>{d.title}</li>
+                  ))}
+                </ul>
+              </Popup>
+            </Marker>
+          ))}
+      </MapContainer>
+    </div>
+  );
+}
+
+export default GeoMap;
+


### PR DESCRIPTION
## Summary
- add Leaflet-based GeoMap component with Nominatim geocoding
- show document popups on markers and toggleable heatmap
- register Leaflet dependencies

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b84f5e95288330955c490f9e9f0a83