### PR TITLE
feat: add timeline visualization for documents

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,7 +11,9 @@
         "cytoscape": "^3.33.1",
         "leaflet": "^1.9.4",
         "leaflet.heat": "^0.2.0",
+        "moment": "^2.30.1",
         "react": "^19.1.1",
+        "react-calendar-timeline": "^0.30.0-beta.3",
         "react-dom": "^19.1.1",
         "react-leaflet": "^5.0.0"
       },
@@ -985,6 +987,13 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@interactjs/types": {
+      "version": "1.10.27",
+      "resolved": "https://registry.npmjs.org/@interactjs/types/-/types-1.10.27.tgz",
+      "integrity": "sha512-BUdv0cvs4H5ODuwft2Xp4eL8Vmi3LcihK42z0Ft/FbVJZoRioBsxH+LlsBdK4tAie7PqlKGy+1oyOncu1nQ6eA==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1506,6 +1515,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/batch-processor": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/batch-processor/-/batch-processor-1.0.0.tgz",
+      "integrity": "sha512-xoLQD8gmmR32MeuBHgH0Tzd5PuSZx71ZsbhVxOCRbgktZEPe4SQy7s9Z50uPp0F/f7iw2XmkHN2xkgbMfckMDA==",
+      "license": "MIT"
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -1598,6 +1613,12 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "license": "MIT"
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1663,6 +1684,13 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/dayjs": {
+      "version": "1.11.18",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.18.tgz",
+      "integrity": "sha512-zFBQ7WFRvVRhKcWoUh+ZA1g2HVgUbsZm9sbddh8EC5iv93sui8DVVz1Npvz+r6meo9VKfa8NyLWBsQK1VvIKPA==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/debug": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
@@ -1694,6 +1722,15 @@
       "integrity": "sha512-xr9eRzSLNa4neDO0xVFrkXu3vyIzG4Ay08dApecw42Z1NbmCt+keEpXdvlYGVe0wtvY5dhW0Ay0lY0IOfsCg0Q==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/element-resize-detector": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/element-resize-detector/-/element-resize-detector-1.2.4.tgz",
+      "integrity": "sha512-Fl5Ftk6WwXE0wqCgNoseKWndjzZlDCwuPTcoVZfCP9R3EHQF8qUtr3YUPNETegRBOKqQKPW3n4kiIWngGi8tKg==",
+      "license": "MIT",
+      "dependencies": {
+        "batch-processor": "1.0.0"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.25.9",
@@ -2126,6 +2163,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/interactjs": {
+      "version": "1.10.27",
+      "resolved": "https://registry.npmjs.org/interactjs/-/interactjs-1.10.27.tgz",
+      "integrity": "sha512-y/8RcCftGAF24gSp76X2JS3XpHiUvDQyhF8i7ujemBz77hwiHDuJzftHx7thY8cxGogwGiPJ+o97kWB6eAXnsA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@interactjs/types": "1.10.27"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2274,6 +2321,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -2291,6 +2344,12 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/memoize-one": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
+      "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==",
+      "license": "MIT"
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -2300,6 +2359,15 @@
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "license": "MIT",
       "engines": {
         "node": "*"
       }
@@ -2503,6 +2571,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-calendar-timeline": {
+      "version": "0.30.0-beta.3",
+      "resolved": "https://registry.npmjs.org/react-calendar-timeline/-/react-calendar-timeline-0.30.0-beta.3.tgz",
+      "integrity": "sha512-TckfoAzJvK5FEQo83vejbVtSDX1XNxcFmfCq92lMZKQiEuzbk7adcQi+ySlL9uSZ1ulFZS6YMAS6rzEGsVtZ2A==",
+      "license": "MIT",
+      "dependencies": {
+        "classnames": "^2.5.1",
+        "element-resize-detector": "^1.2.4",
+        "lodash": "^4.17.21",
+        "memoize-one": "^6.0.0"
+      },
+      "peerDependencies": {
+        "dayjs": ">=1.10.0",
+        "interactjs": "1.10.27",
+        "react": "^18 || ^19.0.0-rc-66855b96-20241106",
+        "react-dom": "^18 || ^19.0.0-rc-66855b96-20241106"
       }
     },
     "node_modules/react-dom": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,9 @@
     "cytoscape": "^3.33.1",
     "leaflet": "^1.9.4",
     "leaflet.heat": "^0.2.0",
+    "moment": "^2.30.1",
     "react": "^19.1.1",
+    "react-calendar-timeline": "^0.30.0-beta.3",
     "react-dom": "^19.1.1",
     "react-leaflet": "^5.0.0"
   },

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,6 +4,7 @@ import DocumentBrowser from './components/DocumentBrowser';
 import GlobalSearch from './components/GlobalSearch';
 import ConnectionsMap from './components/ConnectionsMap';
 import GeoMap from './components/GeoMap';
+import EventTimeline from './components/EventTimeline';
 
 function App() {
   return (
@@ -11,6 +12,7 @@ function App() {
       <h1>Document Browser</h1>
       <GlobalSearch />
       <DocumentBrowser />
+      <EventTimeline />
       <ConnectionsMap />
       <GeoMap
         locations={[

--- a/frontend/src/components/EventTimeline.jsx
+++ b/frontend/src/components/EventTimeline.jsx
@@ -1,0 +1,70 @@
+import React, { useEffect, useState } from 'react';
+import Timeline from 'react-calendar-timeline';
+import moment from 'moment';
+import 'react-calendar-timeline/dist/style.css';
+
+function EventTimeline() {
+  const [items, setItems] = useState([]);
+
+  const groups = [
+    { id: 1, title: 'Threads' },
+    { id: 2, title: 'Publications' },
+    { id: 3, title: 'Persons' }
+  ];
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await fetch('/data/index.json');
+        if (!res.ok) return;
+        const docs = await res.json();
+        const timelineItems = docs.slice(0, 100).map((doc, idx) => {
+          const start = doc.date ? moment(doc.date) : moment();
+          let group = 2;
+          if (doc.filePath && doc.filePath.toLowerCase().includes('thread')) {
+            group = 1;
+          } else if (doc.entities && doc.entities.length > 0) {
+            group = 3;
+          }
+          return {
+            id: idx + 1,
+            group,
+            title: doc.title || doc.filePath,
+            start_time: start,
+            end_time: start.clone().add(1, 'hour'),
+            itemProps: { 'data-url': doc.filePath }
+          };
+        });
+        setItems(timelineItems);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    load();
+  }, []);
+
+  const handleItemClick = (itemId) => {
+    const item = items.find((i) => i.id === itemId);
+    if (item) {
+      const url = item.itemProps['data-url'];
+      if (url) {
+        const link = url.startsWith('http') ? url : `/${url}`;
+        window.open(link, '_blank');
+      }
+    }
+  };
+
+  return (
+    <div>
+      <Timeline
+        groups={groups}
+        items={items}
+        onItemClick={handleItemClick}
+        defaultTimeStart={moment().add(-1, 'month')}
+        defaultTimeEnd={moment().add(1, 'month')}
+      />
+    </div>
+  );
+}
+
+export default EventTimeline;


### PR DESCRIPTION
## Summary
- add react-calendar-timeline to show threads, publications, and person links
- load document metadata into a timeline and open documents on click
- include timeline component in the main app

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b850237c4c83309b830d5cd0effaff