### PR TITLE
feat: add OCR extraction and search indexing

### DIFF
--- a/backend/load_index.py
+++ b/backend/load_index.py
@@ -42,6 +42,14 @@ def load_index(index_file: Path = DEFAULT_INDEX_FILE, index_name: str = DEFAULT_
         documents = data
 
     index.update_filterable_attributes(["type", "source", "topics", "entities"])
+    index.update_searchable_attributes([
+        "title",
+        "ocrText",
+        "source",
+        "topics",
+        "entities",
+        "tags",
+    ])
     index.add_documents(documents)
 
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,3 +4,4 @@ uvicorn[standard]
 fpdf2
 python-jose[cryptography]
 passlib[bcrypt]
+pytesseract

--- a/frontend/src/components/GlobalSearch.jsx
+++ b/frontend/src/components/GlobalSearch.jsx
@@ -42,12 +42,15 @@ function GlobalSearch() {
       />
       {results.length > 0 && (
         <ul>
-          {results.map((hit) => {
-            const snippet =
-              (hit._formatted &&
-                (hit._formatted.content || hit._formatted.text || '')) ||
-              '';
-            return (
+            {results.map((hit) => {
+              const snippet =
+                (hit._formatted &&
+                  (hit._formatted.content ||
+                    hit._formatted.text ||
+                    hit._formatted.ocrText ||
+                    '')) ||
+                '';
+              return (
               <li key={hit.id} style={{ marginBottom: '1rem' }}>
                 <strong>{hit.title || hit.id}</strong>
                 {snippet && (


### PR DESCRIPTION
## Summary
- use pytesseract to OCR images and store text in `ocrText`
- index `ocrText` for search and expose snippets in global search
- document pytesseract dependency

## Testing
- `python -m py_compile scripts/ingest_resources.py backend/load_index.py`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b8535d6b4883309580febbc889e508