### PR TITLE
Add tests, docker-compose, and start guide

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,49 @@
+version: '3.8'
+services:
+  backend:
+    image: python:3.11-slim
+    working_dir: /code
+    volumes:
+      - .:/code
+    command: bash -c "pip install -r backend/requirements.txt && uvicorn backend.app:app --host 0.0.0.0 --port 8000"
+    environment:
+      MEILISEARCH_HOST: http://search:7700
+      MEILISEARCH_API_KEY: ${MEILI_MASTER_KEY:-masterKey}
+    ports:
+      - "8000:8000"
+    depends_on:
+      - search
+      - db
+  frontend:
+    image: node:18
+    working_dir: /code/frontend
+    volumes:
+      - ./frontend:/code/frontend
+    command: bash -c "npm install && npm run dev -- --host 0.0.0.0"
+    ports:
+      - "5173:5173"
+    depends_on:
+      - backend
+  search:
+    image: getmeili/meilisearch:v1.7
+    environment:
+      MEILI_NO_ANALYTICS: "true"
+      MEILI_MASTER_KEY: ${MEILI_MASTER_KEY:-masterKey}
+    ports:
+      - "7700:7700"
+    volumes:
+      - meili_data:/meili_data
+    command: meilisearch --db-path /meili_data --http-addr '0.0.0.0:7700'
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_DB: app
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+volumes:
+  meili_data:
+  postgres_data:

--- a/start.md
+++ b/start.md
@@ -1,0 +1,31 @@
+# Start Guide
+
+This project bundles a frontend dashboard, FastAPI backend, Meilisearch index and a PostgreSQL database. Docker Compose is used to launch all components together.
+
+## Voraussetzungen
+* [Docker](https://docs.docker.com/get-docker/)
+* [Docker Compose](https://docs.docker.com/compose/)
+
+## Starten
+1. Öffne ein Terminal im Projektverzeichnis.
+2. Starte alle Dienste:
+   ```bash
+   docker-compose up
+   ```
+   Das Frontend läuft danach unter http://localhost:5173 und das Backend unter http://localhost:8000.
+
+## Anmeldung
+Im Login-Dialog der Anwendung können die folgenden Testbenutzer genutzt werden:
+
+| Benutzername | Passwort | Rolle  |
+|--------------|----------|--------|
+| `alice`      | `secret` | Nutzer |
+| `admin`      | `admin`  | Admin  |
+
+## Nutzung
+* **Suche**: Gib einen Begriff ein und filtere nach Typ, Quelle, Themen oder Entitäten.
+* **Dokumente**: Öffne einen Treffer, um Metadaten einzusehen.
+* **Notizen**: Als eingeloggter Nutzer können Notizen und Tags zu einem Dokument gespeichert werden.
+* **Export**: Admins können gespeicherte Notizen als CSV oder PDF herunterladen.
+
+Für eine Übersicht der API besuche http://localhost:8000/docs sobald die Dienste laufen.

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,66 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+sys.path.append(str(ROOT / 'backend'))
+
+from fastapi.testclient import TestClient
+
+import backend.app as app_module
+
+# Patch global state to avoid file I/O during tests
+app_module.NOTES = {}
+app_module._save_notes = lambda: None
+app_module._log_audit = lambda *a, **k: None
+
+client = TestClient(app_module.app)
+
+
+def get_token(username="alice", password="secret"):
+    response = client.post("/token", data={"username": username, "password": password})
+    assert response.status_code == 200
+    return response.json()["access_token"]
+
+
+def test_notes_crud():
+    token = get_token()
+    headers = {"Authorization": f"Bearer {token}"}
+
+    # Initially no note
+    r = client.get("/notes/doc1", headers=headers)
+    assert r.status_code == 200
+    assert r.json() == {"text": "", "tags": []}
+
+    # Save note
+    payload = {"text": "Hello", "tags": ["tag1"]}
+    r = client.post("/notes/doc1", headers=headers, json=payload)
+    assert r.status_code == 200
+    assert app_module.NOTES["doc1"] == payload
+
+    # Retrieve note
+    r = client.get("/notes/doc1", headers=headers)
+    assert r.json() == payload
+
+
+def test_notes_auth_required():
+    r = client.get("/notes/doc1")
+    assert r.status_code == 401
+
+
+def test_search_endpoint(monkeypatch):
+    called = {}
+
+    def fake_search(q, **kwargs):
+        called["q"] = q
+        called.update(kwargs)
+        return {"hits": []}
+
+    monkeypatch.setattr(app_module, "ms_search", fake_search)
+
+    r = client.get("/search", params={"q": "test", "type": ["a"], "limit": 5})
+    assert r.status_code == 200
+    assert r.json() == {"hits": []}
+    assert called["q"] == "test"
+    assert called["types"] == ["a"]
+    assert called["limit"] == 5

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -1,0 +1,46 @@
+import json
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import backend.load_index as load_index_module
+
+
+def test_load_index(monkeypatch, tmp_path):
+    # Create temporary index file
+    data = {"documents": [{"id": 1, "title": "Doc"}]}
+    index_file = tmp_path / "index.json"
+    index_file.write_text(json.dumps(data))
+
+    # Prepare fake client and index to capture interactions
+    calls = {}
+
+    class FakeIndex:
+        def update_filterable_attributes(self, attrs):
+            calls["filterable"] = attrs
+
+        def update_searchable_attributes(self, attrs):
+            calls["searchable"] = attrs
+
+        def add_documents(self, docs):
+            calls["docs"] = docs
+
+    class FakeClient:
+        def __init__(self, host, key):
+            self.host = host
+            self.key = key
+
+        def get_index(self, name):
+            raise Exception("missing index")
+
+        def create_index(self, name, config):
+            calls["created_index"] = name
+            return FakeIndex()
+
+    monkeypatch.setattr(load_index_module, "Client", FakeClient)
+
+    load_index_module.load_index(index_file=index_file, index_name="test")
+
+    assert calls["created_index"] == "test"
+    assert calls["docs"] == data["documents"]


### PR DESCRIPTION
## Summary
- add pytest coverage for search index ingestion and API interactions
- provide docker-compose for backend, frontend, Meilisearch, and PostgreSQL
- document how to start the stack and log in via new `start.md`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b85574a34c8330baf9e75f3026235b