### PR TITLE
fix backend search import

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -16,7 +16,7 @@ from passlib.context import CryptContext
 from pydantic import BaseModel
 from meilisearch import Client
 
-from search import DEFAULT_INDEX_NAME, search as ms_search
+from .search import DEFAULT_INDEX_NAME, search as ms_search
 
 BASE_DIR = Path(__file__).resolve().parents[1]
 METADATA_FILE = BASE_DIR / "data" / "index.json"

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,3 +5,5 @@ fpdf2
 python-jose[cryptography]
 passlib[bcrypt]
 pytesseract
+python-multipart
+httpx


### PR DESCRIPTION
## Summary
- fix missing search module import by using package-relative path
- include python-multipart and httpx in backend requirements

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b858bab334833098010f17803265bb