### PR TITLE
Revamp document browser UI

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,8 +3,14 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap"
+      rel="stylesheet"
+    />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React</title>
+    <title>Document Browser</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,42 +1,13 @@
-#root {
-  max-width: 1280px;
+.App {
+  max-width: 1200px;
   margin: 0 auto;
   padding: 2rem;
+}
+
+.app-header {
   text-align: center;
+  margin-bottom: 2rem;
+  font-size: 2.5rem;
+  font-weight: 600;
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
-}
-
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
-}
-
-.card {
-  padding: 2em;
-}
-
-.read-the-docs {
-  color: #888;
-}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -9,7 +9,7 @@ import EventTimeline from './components/EventTimeline';
 function App() {
   return (
     <div className="App">
-      <h1>Document Browser</h1>
+      <h1 className="app-header">Document Browser</h1>
       <GlobalSearch />
       <DocumentBrowser />
       <EventTimeline />

--- a/frontend/src/components/DocumentBrowser.css
+++ b/frontend/src/components/DocumentBrowser.css
@@ -1,0 +1,60 @@
+.browser-container {
+  background: #fff;
+  padding: 1.5rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+  margin-bottom: 2rem;
+}
+
+.toolbar,
+.filters,
+.view-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+  flex-wrap: wrap;
+}
+
+.view-toggle button.active {
+  background-color: #2b6cb0;
+}
+
+.filters label {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.9rem;
+  color: #4a5568;
+}
+
+.docs {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.docs.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 1rem;
+}
+
+.doc-card {
+  border: 1px solid #e2e8f0;
+  padding: 1rem;
+  border-radius: 6px;
+  background: #fdfdfd;
+  cursor: pointer;
+  transition: box-shadow 0.2s ease;
+  text-align: left;
+}
+
+.doc-card:hover {
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+}
+
+.doc-title {
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+

--- a/frontend/src/components/DocumentBrowser.jsx
+++ b/frontend/src/components/DocumentBrowser.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import DocumentViewer from './DocumentViewer';
+import './DocumentBrowser.css';
 
 const documents = [
   {
@@ -47,17 +48,13 @@ function DocumentBrowser() {
   });
 
   return (
-    <div>
-      <div style={{ marginBottom: '1rem' }}>
+    <div className="browser-container">
+      <div className="toolbar">
         <button onClick={() => window.open('/export?format=pdf')}>Export PDF</button>
-        <button
-          onClick={() => window.open('/export?format=csv')}
-          style={{ marginLeft: '0.5rem' }}
-        >
-          Export CSV
-        </button>
+        <button onClick={() => window.open('/export?format=csv')}>Export CSV</button>
       </div>
-      <div style={{ marginBottom: '1rem' }}>
+
+      <div className="filters">
         <label>
           Type:
           <select name="type" value={filters.type} onChange={handleFilterChange}>
@@ -67,7 +64,7 @@ function DocumentBrowser() {
             <option value="image">Image</option>
           </select>
         </label>
-        <label style={{ marginLeft: '1rem' }}>
+        <label>
           Topic:
           <input
             type="text"
@@ -77,7 +74,7 @@ function DocumentBrowser() {
             placeholder="Topic"
           />
         </label>
-        <label style={{ marginLeft: '1rem' }}>
+        <label>
           Date:
           <input
             type="date"
@@ -88,35 +85,29 @@ function DocumentBrowser() {
         </label>
       </div>
 
-      <div style={{ marginBottom: '1rem' }}>
-        <button onClick={() => setView('list')}>List</button>
-        <button onClick={() => setView('grid')} style={{ marginLeft: '0.5rem' }}>
+      <div className="view-toggle">
+        <button
+          className={view === 'list' ? 'active' : ''}
+          onClick={() => setView('list')}
+        >
+          List
+        </button>
+        <button
+          className={view === 'grid' ? 'active' : ''}
+          onClick={() => setView('grid')}
+        >
           Grid
         </button>
       </div>
 
-      <div
-        style={
-          view === 'grid'
-            ? {
-                display: 'grid',
-                gridTemplateColumns: 'repeat(auto-fill, minmax(150px, 1fr))',
-                gap: '1rem'
-              }
-            : {}
-        }
-      >
+      <div className={`docs ${view === 'grid' ? 'grid' : ''}`}>
         {filteredDocs.map((doc) => (
           <div
             key={doc.id}
             onClick={() => setSelected(doc)}
-            style={{
-              border: '1px solid #ccc',
-              padding: '0.5rem',
-              cursor: 'pointer'
-            }}
+            className="doc-card"
           >
-            <strong>{doc.title}</strong>
+            <strong className="doc-title">{doc.title}</strong>
             <div>{doc.type.toUpperCase()}</div>
             <div>{doc.topic}</div>
             <div>{doc.date}</div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,12 +1,9 @@
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  font-family: 'Inter', system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
+  color: #1a202c;
+  background-color: #f4f6f8;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
@@ -15,54 +12,41 @@
 
 a {
   font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
+  color: #2b6cb0;
+  text-decoration: none;
 }
 a:hover {
-  color: #535bf2;
+  color: #2c5282;
 }
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
 }
 
 h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
+  font-size: 2rem;
+  line-height: 1.2;
 }
 
 button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
+  border-radius: 6px;
+  border: none;
+  padding: 0.5rem 1rem;
+  font-size: 1rem;
   font-weight: 500;
   font-family: inherit;
-  background-color: #1a1a1a;
+  background-color: #3182ce;
+  color: #fff;
   cursor: pointer;
-  transition: border-color 0.25s;
+  transition: background-color 0.2s ease;
 }
 button:hover {
-  border-color: #646cff;
+  background-color: #2b6cb0;
 }
 button:focus,
 button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+  outline: 2px solid #2b6cb0;
+  outline-offset: 2px;
 }


### PR DESCRIPTION
## Summary
- modernize document browser with card-based grid/list layout and clean filtering controls
- introduce global styling with Inter font and improved color palette
- style app container and header for a more polished layout

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b85d2947e8833095b94c0a6f3fdb2c